### PR TITLE
support peerDependencies >= react 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@storybook/api": "^6.0.22"
   },
   "peerDependencies": {
-    "react": "^16.13.1"
+    "react": ">=16.13.1"
   },
   "devDependencies": {
     "@babel/cli": "7.11.6",
@@ -60,7 +60,7 @@
     "husky": "4.3.0",
     "lint-staged": "10.3.0",
     "prettier": "2.1.1",
-    "react": "^16.13.1",
+    "react": "18.2.0",
     "semantic-release": "17.1.1",
     "typescript": "4.0.2"
   }


### PR DESCRIPTION
I have upgraded react version to 18.2.0 as @storybook/addons need to react 18.2.0. Please verify all my changes. 
